### PR TITLE
Modernize UI and refactor page structure

### DIFF
--- a/attendance_preview.php
+++ b/attendance_preview.php
@@ -348,16 +348,33 @@ include 'layouts/sidebar.php';
                                         <?php endif; ?>
                                     </td>
                                     <td>
-                                        <?php if ($row['work_duration']): ?>
+                                        <?php if ($row['work_duration'] && $row['work_duration'] != '00:00:00'): ?>
                                             <?php
+                                            // Parse time duration (format: HH:MM:SS)
                                             $duration = $row['work_duration'];
-                                            $hours = floor($duration / 10000);
-                                            $minutes = floor(($duration % 10000) / 100);
+                                            $timeParts = explode(':', $duration);
+                                            
+                                            // Ensure we have valid time parts
+                                            if (count($timeParts) >= 2) {
+                                                $hours = intval($timeParts[0]);
+                                                $minutes = intval($timeParts[1]);
+                                                
+                                                // Display duration
+                                                if ($hours > 0 || $minutes > 0) {
+                                                    echo '<div class="text-info">';
+                                                    echo '<i class="bi bi-stopwatch me-1"></i>';
+                                                    echo '<strong>';
+                                                    if ($hours > 0) echo $hours . 'h ';
+                                                    if ($minutes > 0) echo $minutes . 'm';
+                                                    echo '</strong>';
+                                                    echo '</div>';
+                                                } else {
+                                                    echo '<span class="text-muted">0h 0m</span>';
+                                                }
+                                            } else {
+                                                echo '<span class="text-muted">Invalid</span>';
+                                            }
                                             ?>
-                                            <div class="text-info">
-                                                <i class="bi bi-stopwatch me-1"></i>
-                                                <strong><?= $hours ?>h <?= $minutes ?>m</strong>
-                                            </div>
                                         <?php else: ?>
                                             <span class="text-muted">N/A</span>
                                         <?php endif; ?>


### PR DESCRIPTION
Fix non-numeric value warning in attendance preview work duration calculation.

Correctly parse `TIMEDIFF()` string output (HH:MM:SS) into hours and minutes to prevent PHP warnings and accurately display work durations.

---

**Open Background Agent:** 
[Web](https://www.cursor.com/agents?id=bc-281f3a83-1725-49a5-aa1a-8659dd45cb29) · [Cursor](https://cursor.com/background-agent?bcId=bc-281f3a83-1725-49a5-aa1a-8659dd45cb29)

Learn more about [Background Agents](https://docs.cursor.com/background-agent/web-and-mobile)